### PR TITLE
Add support for an alternate RADAR server.

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -17,7 +17,9 @@ def parseArgs():
 	parser.add_option( '-d', '--date', dest='base_date', default=_d, help="base date for data", metavar="DDMMMYYY" )
 	parser.add_option( '-t', '--time', dest='base_time', default=_t, help="base time for data", metavar="HHMM")
 	parser.add_option( '-a', '--address', dest='host', default='localhost', help="location for data connections", metavar='IP Address:port, hostname:port, or query URL base (for JSON)')
+	parser.add_option( '-A', '--alternate', dest='alternate', default=None, help="alternate location for data connections, if the primary is unavailable (only for JSON)", metavar='IP Address:port, hostname:port, or query URL base (for JSON)')
 	parser.add_option( '-z', '--tz', dest='tz', default=_z, help="default timezone", metavar='Time Zone Name')
+	parser.add_option( '-O', '--office', dest='office', default=None, help="default office to use if not specified in report", metavar='OFFICE_ID')
 	parser.add_option( '-c', '--compatibility', dest='compat', action="store_true", default=False, help="repgen4 compatibility; case-insensitive labels")
 	parser.add_option( '-V', '--version',dest='show_ver',action='store_true',default=False, help="print version number")
 	parser.add_option( '-f', '--file', dest='data_file', default=None, help="Variable data file", metavar="DATAFILE" )
@@ -47,6 +49,21 @@ TIMEZONE_ALIASES = {
 }
 
 if __name__ == "__main__":
+	def filterAddress(address):
+		if address is None:
+			return (None, None)
+
+		# Check for protocol (e.g. https://)
+		# We don't actually care about it, so discard it (repgen only works with http or https)
+		match = re.match(r"(https?:\/\/)?(.+)", address)
+		host = match.group(2)
+		query = None
+		if '/' in host:
+			parts = host.split('/', 1)
+			host = parts[0]
+			query = parts[1] if len(parts) > 1 else None
+
+		return (host, query)
 
 	config = parseArgs()
 
@@ -55,15 +72,9 @@ if __name__ == "__main__":
 		sys.exit(0)
 
 	report_file = config.in_file
-	host = config.host
-	query = None
 
-	# Check for protocol (e.g. https://)
-	# We don't actually care about it, so discard it (repgen only works with http or https)
-	match = re.match(r"(https?:\/\/)?(.+)", host)
-	host = match.group(2)
-	if '/' in host:
-		(host, query) = host.split('/', 1)
+	(host, path) = filterAddress(config.host)
+	(althost, altpath) = filterAddress(config.alternate)
 
 	tz = None
 
@@ -83,7 +94,7 @@ if __name__ == "__main__":
 		tz = pytz.timezone(TIMEZONE_ALIASES.get(tz, tz))
 
 	# set some of the default values
-	Value(1, host=host, query=query, tz=tz, ucformat=config.compat, timeout=config.timeout)
+	Value(1, host=host, path=path, tz=tz, ucformat=config.compat, timeout=config.timeout, althost=althost, altpath=altpath, dbofc=config.office)
 	
 	# read the report file
 	f = open(report_file)

--- a/__main__.py
+++ b/__main__.py
@@ -24,6 +24,11 @@ def parseArgs():
 	parser.add_option( '-V', '--version',dest='show_ver',action='store_true',default=False, help="print version number")
 	parser.add_option( '-f', '--file', dest='data_file', default=None, help="Variable data file", metavar="DATAFILE" )
 	parser.add_option( '', '--timeout', dest='timeout', type="float", default=None, help="Socket timeout, in seconds" )
+
+	if len(sys.argv) == 1:
+		parser.print_help()
+		exit(2)
+
 	return parser.parse_args()[0]
 
 # Pytz does't know all the aliases and abbreviations

--- a/repgen/data/value.py
+++ b/repgen/data/value.py
@@ -337,26 +337,26 @@ class Value:
 			sstart = self.start
 			send = self.end
 
-			# Convert time to destination timezone
-			# Should this actually convert the time to the destination time zone (astimezone), or simply swap the TZ (replace)?
-			# 'astimezone' would be the "proper" behavior, but 'replace' mimics repgen_4.
-			start = tz.localize(sstart.replace(tzinfo=None))
-			end = tz.localize(send.replace(tzinfo=None))
 			path = self.path if not Value.shared["use_alternate"] else self.altpath
 			host = self.host if not Value.shared["use_alternate"] else self.althost
 			headers = { 'Accept': "application/json;version=2" }
 
-			params = urllib.urlencode( {
-				"name": ts_name,
-				"unit": units,
-				"begin": start.strftime(fmt),
-				"end":   end.strftime(fmt),
-				"office": self.dbofc if self.dbofc is not None else "",
-				"timezone": str(tz),
-				"pageSize": -1,					# always fetch all results
-			})
-
 			while(retry_count > 0):
+				# Convert time to destination timezone
+				# Should this actually convert the time to the destination time zone (astimezone), or simply swap the TZ (replace)?
+				# 'astimezone' would be the "proper" behavior, but 'replace' mimics repgen_4.
+				start = tz.localize(sstart.replace(tzinfo=None))
+				end = tz.localize(send.replace(tzinfo=None))
+				params = urllib.urlencode( {
+					"name": ts_name,
+					"unit": units,
+					"begin": start.strftime(fmt),
+					"end":   end.strftime(fmt),
+					"office": self.dbofc if self.dbofc is not None else "",
+					"timezone": str(tz),
+					"pageSize": -1,					# always fetch all results
+				})
+
 				sys.stderr.write("Getting %s from %s to %s in tz %s, with units %s\n" % (ts_name,start.strftime(fmt),end.strftime(fmt),str(tz),units))
 
 				try:


### PR DESCRIPTION
This adds support for specifying an alternate backup RADAR instance to use if the primary is unavailable or providing garbage results.
Also implement DBOFC keyword, and ability to specify a default office on the command-line. This is needed for some alternate servers.